### PR TITLE
Fix contestant card usage

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useState } from 'react';
 import { db } from './firebase';
 import { collection, getDocs } from 'firebase/firestore';
+import ContestantCard from './ContestantCard';
 
 const App = () => {
   const [contestants, setContestants] = useState([]);
@@ -26,11 +27,7 @@ const App = () => {
 
       <div style={{ display: 'flex', flexWrap: 'wrap', justifyContent: 'center' }}>
         {contestants.map((c) => (
-          <div key={c.id} style={{ margin: '1rem', border: '1px solid #ddd', padding: '1rem' }}>
-            <img src={c.image} alt={c.name} style={{ width: 200, height: 200, objectFit: 'cover' }} />
-            <h3>{c.name}</h3>
-            <p>Votes: {c.votes}</p>
-          </div>
+          <ContestantCard key={c.id} data={c} />
         ))}
       </div>
     </div>

--- a/client/src/ContestantCard.jsx
+++ b/client/src/ContestantCard.jsx
@@ -1,5 +1,12 @@
 export default function ContestantCard({ data }) {
-  const { name, flag, photoURL, votes = 0 } = data;
+  const {
+    name,
+    flag,
+    photoURL,
+    image,
+    votes = 0,
+  } = data;
+  const imgSrc = photoURL || image || '';
 
   const handleVote = (amount) => {
     alert(`Vote for $${amount} coming soon!`);
@@ -7,7 +14,7 @@ export default function ContestantCard({ data }) {
 
   return (
     <div className="card">
-      <img src={photoURL} alt={name} />
+      <img src={imgSrc} alt={name} style={{ width: 200, height: 200, objectFit: 'cover' }} />
       <h2>{flag} {name}</h2>
       <p>Votes: {votes}</p>
       {[1, 5, 10, 20].map(amount => (


### PR DESCRIPTION
## Summary
- show contestant details with `ContestantCard`
- support `image` or `photoURL` fields for contestant photos

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_685f90025028832fbbb098116fc5e677